### PR TITLE
Issue 192 Drawing Optimisation

### DIFF
--- a/ui/dashboard/src/components/stage/Toolbox/TopBar.vue
+++ b/ui/dashboard/src/components/stage/Toolbox/TopBar.vue
@@ -76,7 +76,6 @@ export default {
       &:hover,
       &.active {
         cursor: pointer;
-        transform: scale(1.2);
         img {
           -webkit-filter: drop-shadow(5px 5px 5px $dark);
           filter: drop-shadow(5px 5px 5px $dark);

--- a/ui/dashboard/src/components/stage/Toolbox/tools/Draw/index.vue
+++ b/ui/dashboard/src/components/stage/Toolbox/tools/Draw/index.vue
@@ -2,10 +2,10 @@
   <canvas
     v-show="isDrawing"
     ref="el"
-    width="3840"
-    height="2160"
+    :width="stageSize.width"
+    :height="stageSize.height"
     class="drawing"
-    :style="{ cursor }"
+    :style="{ cursor, top: stageSize.top + 'px', left: stageSize.left + 'px' }"
   >
     Your browser does not support the HTML5 canvas tag.
   </canvas>
@@ -99,6 +99,7 @@ export default {
   components: { Skeleton, ColorPicker, Icon },
   setup: () => {
     const store = useStore();
+    const stageSize = computed(() => store.getters["stage/stageSize"]);
     const drawings = computed(() => store.state.stage.board.drawings);
     const isDrawing = computed(() => {
       return store.state.stage.preferences.isDrawing;
@@ -145,6 +146,7 @@ export default {
       toggleErase,
       mode,
       cursor,
+      stageSize,
     };
   },
 };
@@ -155,14 +157,10 @@ export default {
 
 .drawing {
   position: fixed;
-  top: 0;
-  left: 0vh;
   z-index: 1000;
-  background-color: rgba($color: white, $alpha: 0.5);
-  backdrop-filter: blur(5px);
+  background-color: rgba($color: white, $alpha: 0.8);
 }
 .drawing-tool {
-  background-color: rgba($color: white, $alpha: 0.5);
   z-index: 1001;
   position: relative;
   vertical-align: top;

--- a/ui/dashboard/src/components/stage/Toolbox/tools/Draw/index.vue
+++ b/ui/dashboard/src/components/stage/Toolbox/tools/Draw/index.vue
@@ -1,10 +1,10 @@
 <template>
   <canvas
-    v-show="isDrawing"
     ref="el"
+    v-show="isDrawing"
+    class="drawing"
     :width="stageSize.width"
     :height="stageSize.height"
-    class="drawing"
     :style="{ cursor, top: stageSize.top + 'px', left: stageSize.left + 'px' }"
   >
     Your browser does not support the HTML5 canvas tag.
@@ -55,7 +55,7 @@
       </div>
       <span class="tag is-light is-block">Undo</span>
     </div>
-    <div class="drawing-tool" @click="clearCanvas">
+    <div class="drawing-tool" @click="clearCanvas(true)">
       <div class="icon is-large">
         <i class="fas fa-broom fa-2x"></i>
       </div>
@@ -88,9 +88,9 @@
 </template>
 
 <script>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useStore } from "vuex";
-import { useDrawing } from "./composable";
+import useDrawing from "./useDrawing";
 import Skeleton from "@/components/objects/Skeleton";
 import ColorPicker from "@/components/form/ColorPicker";
 import Icon from "@/components/Icon";
@@ -104,14 +104,17 @@ export default {
     const isDrawing = computed(() => {
       return store.state.stage.preferences.isDrawing;
     });
-    const color = ref("#000");
-    const size = ref(10);
-    const mode = ref("draw");
-    const { el, cursor, cropImageFromCanvas, clearCanvas, undo } = useDrawing(
+    const {
+      el,
+      cursor,
+      cropImageFromCanvas,
+      clearCanvas,
+      undo,
+      toggleErase,
       color,
       size,
-      mode
-    );
+      mode,
+    } = useDrawing();
     const create = () => {
       store.commit("stage/UPDATE_IS_DRAWING", true);
     };
@@ -122,13 +125,6 @@ export default {
       const drawing = cropImageFromCanvas();
       if (drawing) {
         store.dispatch("stage/addDrawing", drawing);
-      }
-    };
-    const toggleErase = () => {
-      if (mode.value === "erase") {
-        mode.value = "draw";
-      } else {
-        mode.value = "erase";
       }
     };
 

--- a/ui/dashboard/src/components/stage/Toolbox/tools/Draw/useDrawing.js
+++ b/ui/dashboard/src/components/stage/Toolbox/tools/Draw/useDrawing.js
@@ -1,36 +1,69 @@
 import { computed, onMounted, reactive, ref } from "vue";
 import * as canvasUtil from '@/utils/canvas';
 
-export const useDrawing = (color, size, mode) => {
+const eraseDot = (ctx, { x, y, size }) => {
+    ctx.clearRect(x, y, size, size);
+}
+
+const drawDot = (ctx, { x, y, size, color }) => {
+    ctx.beginPath();
+    ctx.arc(x, y, size / 2, 0, Math.PI * 2, true);
+    ctx.closePath();
+    ctx.fillStyle = color;
+    ctx.fill();
+};
+
+const draw = (ctx, { fromX, fromY, x, y, size, color }) => {
+    ctx.beginPath();
+    ctx.moveTo(fromX, fromY);
+    ctx.lineTo(x, y);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = size;
+    ctx.stroke();
+    ctx.closePath();
+    drawDot(ctx, { x: fromX, y: fromY, size, color });
+};
+
+const execute = (ctx, command) => {
+    const { type, size, color, lines } = command;
+    if (lines && lines.length) {
+        if (type === 'draw') {
+            lines.forEach(({ fromX, fromY, x, y }) => draw(ctx, {
+                fromX, fromY, x, y, size, color
+            }))
+        } else {
+            lines.forEach(({ x, y }) => eraseDot(ctx, {
+                x, y, size
+            }))
+        }
+    } else {
+        if (type === 'draw') {
+            if (command.fromX && command.fromY) {
+                draw(ctx, command)
+            } else {
+                drawDot(ctx, command)
+            }
+        } else {
+            eraseDot(ctx, command);
+        }
+    }
+}
+
+export default () => {
+    const color = ref("#000");
+    const size = ref(10);
+    const mode = ref("draw");
     const el = ref(null);
+
     const data = reactive({
-        history: []
+        history: [],
+        lines: []
     });
 
     const cropImageFromCanvas = () => {
         return canvasUtil.cropImageFromCanvas(el.value);
     };
 
-    const eraseDot = (ctx) => {
-        ctx.clearRect(data.currX, data.currY, size.value, size.value);
-    }
-    const drawDot = (ctx) => {
-        ctx.beginPath();
-        ctx.arc(data.currX, data.currY, size.value / 2, 0, Math.PI * 2, true);
-        ctx.closePath();
-        ctx.fillStyle = color.value;
-        ctx.fill();
-    };
-    const draw = (ctx) => {
-        ctx.beginPath();
-        ctx.moveTo(data.prevX, data.prevY);
-        ctx.lineTo(data.currX, data.currY);
-        ctx.strokeStyle = color.value;
-        ctx.lineWidth = size.value;
-        ctx.stroke();
-        ctx.closePath();
-        drawDot(ctx);
-    };
     const findxy = (res, e) => {
         const { value: canvas } = el;
         const ctx = canvas.getContext("2d");
@@ -41,23 +74,31 @@ export const useDrawing = (color, size, mode) => {
             data.currX = e.clientX - left;
             data.currY = e.clientY - top;
 
+            data.lines = []
             data.flag = true;
             data.dot_flag = true;
-            if (data.dot_flag) {
-                if (mode.value === 'draw') {
-                    drawDot(ctx);
-                }
-                if (mode.value === 'erase') {
-                    eraseDot(ctx);
-                }
+
+            let command = {
+                type: mode.value,
+                x: data.currX,
+                y: data.currY,
+                size: size.value,
+                color: color.value
             }
+            execute(ctx, command)
         }
         if (res == "up" || res == "out") {
             data.flag = false;
         }
         if (res == "up") {
-            data.history.push(cropImageFromCanvas());
-            data.dirty = true;
+            data.history.push({
+                type: mode.value,
+                size: size.value,
+                color: color.value,
+                lines: data.lines,
+                x: data.currX,
+                y: data.currY,
+            })
         }
         if (res == "move") {
             if (data.flag) {
@@ -65,12 +106,20 @@ export const useDrawing = (color, size, mode) => {
                 data.prevY = data.currY;
                 data.currX = e.clientX - left;
                 data.currY = e.clientY - top;
-                if (mode.value === 'draw') {
-                    draw(ctx);
+                const coords = {
+                    x: data.currX,
+                    y: data.currY,
+                    fromX: data.prevX,
+                    fromY: data.prevY,
                 }
-                if (mode.value === 'erase') {
-                    eraseDot(ctx);
+                let command = {
+                    type: mode.value,
+                    size: size.value,
+                    color: color.value,
+                    ...coords
                 }
+                execute(ctx, command)
+                data.lines.push(coords)
             }
         }
     };
@@ -112,27 +161,21 @@ export const useDrawing = (color, size, mode) => {
 
     onMounted(attachEventLinsteners)
 
-    const clearCanvas = () => {
+    const clearCanvas = (clearHistory) => {
         const { value: canvas } = el;
         const ctx = canvas.getContext("2d");
         ctx.clearRect(0, 0, canvas.width, canvas.height);
+        if (clearHistory) {
+            data.history = []
+        }
         return ctx;
     }
 
     const undo = () => {
         const ctx = clearCanvas();
-        let snapshot = data.history.pop();
-        if (data.dirty) {
-            snapshot = data.history.pop();
-            data.dirty = false;
-        }
-        if (snapshot) {
-            const image = document.createElement('img');
-            image.onload = function () {
-                ctx.drawImage(image, snapshot.x, snapshot.y);
-            };
-            image.src = snapshot.src;
-        }
+        data.history.pop();
+        data.history.forEach(command => execute(ctx, command))
+        console.log(data.history)
         return ctx;
     }
 
@@ -159,5 +202,13 @@ export const useDrawing = (color, size, mode) => {
 
     })
 
-    return { el, cursor, cropImageFromCanvas, clearCanvas, undo }
+    const toggleErase = () => {
+        if (mode.value === "erase") {
+            mode.value = "draw";
+        } else {
+            mode.value = "erase";
+        }
+    };
+
+    return { el, cursor, color, size, mode, cropImageFromCanvas, clearCanvas, undo, toggleErase }
 }

--- a/ui/dashboard/src/store/modules/stage/index.js
+++ b/ui/dashboard/src/store/modules/stage/index.js
@@ -33,8 +33,6 @@ export default {
             audios: [],
             streams: [],
             config: {
-                width: 1280,
-                height: 800,
                 animateDuration: 500,
                 reactionDuration: 5000,
                 ratio: 16 / 9,


### PR DESCRIPTION
- Rewrite the undo feature, this is the main cause of the memory leeks

> More details (in case you want to know 😅): In the past every time you draw a line, I generate a whole image from the canvas, and save it to an array of `snapshots`, so when you hit the Undo button, I pop that snapshot image, and redraw it on the canvas. It's easy to implement but caused performance issue, since each snapshot is a base64 present of a picture. Now I use an array of objects, I call it `commands`. A command only contain the type of action (either draw or erase), the coordination, brush size and color,... Command not only reduce the memory used, it also make the Undo working smoother (in the past there was a glitch when you hit Undo button)

- Adjust the canvas size to the stage size
> In the past I fixed the canvas at 3840x2160, now the canvas has the size exactly equal to the size of the stage, which is smaller. But this cause 1 drawback: if you resize your browser tab, the canvas will be cleared
- No blur effect on the canvas, it look less glossy now, but behave smoother ✨ 