### PR TITLE
Issue 219 avatar control

### DIFF
--- a/ui/dashboard/src/components/objects/Avatar/ContextMenu.vue
+++ b/ui/dashboard/src/components/objects/Avatar/ContextMenu.vue
@@ -1,15 +1,19 @@
 <template>
   <div class="avatar-context-menu card-content p-0">
-    <a
-      v-if="object.type !== 'prop'"
-      class="panel-block"
-      @click="setAsPrimaryAvatar"
-    >
-      <span class="panel-icon">
-        <Icon src="set-as-avatar.svg" />
-      </span>
-      <span>Set as your avatar</span>
-    </a>
+    <template v-if="object.type !== 'prop'">
+      <a v-if="isHolding" class="panel-block" @click.stop="releaseAvatar">
+        <span class="panel-icon">
+          <Icon src="clear.svg" />
+        </span>
+        <span>Release this avatar</span>
+      </a>
+      <a v-else class="panel-block" @click="holdAvatar">
+        <span class="panel-icon">
+          <Icon src="set-as-avatar.svg" />
+        </span>
+        <span>Hold this avatar</span>
+      </a>
+    </template>
     <a class="panel-block" @click="bringToFront">
       <span class="panel-icon">
         <Icon src="bring-to-front.svg" />
@@ -126,7 +130,7 @@
 
 <script>
 import { useStore } from "vuex";
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import Icon from "@/components/Icon";
 
 export default {
@@ -136,8 +140,12 @@ export default {
   setup: (props, { emit }) => {
     const store = useStore();
 
-    const setAsPrimaryAvatar = () => {
-      emit("hold");
+    const holdAvatar = () => {
+      store.dispatch("user/setAvatarId", props.object.id).then(props.closeMenu);
+    };
+
+    const releaseAvatar = () => {
+      store.dispatch("user/setAvatarId", null).then(props.closeMenu);
     };
 
     const deleteObject = () => {
@@ -189,9 +197,15 @@ export default {
       });
     };
 
+    const holder = inject("holder");
+    const isHolding = computed(
+      () => holder.value && holder.value.id === store.state.stage.session
+    );
+
     return {
       switchFrame,
-      setAsPrimaryAvatar,
+      holdAvatar,
+      releaseAvatar,
       deleteObject,
       changeNickname,
       bringToFront,
@@ -200,6 +214,7 @@ export default {
       sliderMode,
       changeSliderMode,
       rotate,
+      isHolding,
     };
   },
 };

--- a/ui/dashboard/src/components/objects/Avatar/ContextMenu.vue
+++ b/ui/dashboard/src/components/objects/Avatar/ContextMenu.vue
@@ -131,14 +131,13 @@ import Icon from "@/components/Icon";
 
 export default {
   props: ["object", "closeMenu", "active"],
-  emits: ["update:active"],
+  emits: ["update:active", "hold"],
   components: { Icon },
   setup: (props, { emit }) => {
     const store = useStore();
 
     const setAsPrimaryAvatar = () => {
-      const { name, id } = props.object;
-      store.dispatch("user/setAvatarId", { id, name }).then(props.closeMenu);
+      emit("hold");
     };
 
     const deleteObject = () => {

--- a/ui/dashboard/src/components/objects/Avatar/index.vue
+++ b/ui/dashboard/src/components/objects/Avatar/index.vue
@@ -1,11 +1,10 @@
 <template>
-  <Object :object="object" @hold="setAsPrimaryAvatar">
+  <Object :object="object">
     <template #menu="slotProps">
       <MenuContent
         :object="object"
         :closeMenu="slotProps.closeMenu"
         v-model:active="active"
-        @hold="setAsPrimaryAvatar"
       />
     </template>
   </Object>
@@ -22,21 +21,12 @@ export default {
   components: { Object, MenuContent },
   setup: (props) => {
     const store = useStore();
-    const loggedIn = computed(() => store.getters["auth/loggedIn"]);
     const holder = computed(() =>
       store.state.stage.sessions.find((s) => s.avatarId === props.object.id)
     );
     provide("holder", holder);
 
-    const setAsPrimaryAvatar = () => {
-      if (loggedIn.value && !holder.value && props.object.type !== "prop") {
-        store
-          .dispatch("user/setAvatarId", props.object.id)
-          .then(props.closeMenu);
-      }
-    };
-
-    return { setAsPrimaryAvatar, holder };
+    return { holder };
   },
 };
 </script>

--- a/ui/dashboard/src/components/objects/Avatar/index.vue
+++ b/ui/dashboard/src/components/objects/Avatar/index.vue
@@ -1,22 +1,43 @@
 <template>
-  <Object :object="object">
+  <Object :object="object" @hold="setAsPrimaryAvatar">
     <template #menu="slotProps">
       <MenuContent
         :object="object"
         :closeMenu="slotProps.closeMenu"
         v-model:active="active"
+        @hold="setAsPrimaryAvatar"
       />
     </template>
   </Object>
 </template>
 
 <script>
+import { computed, provide } from "@vue/runtime-core";
 import Object from "../Object.vue";
 import MenuContent from "./ContextMenu";
+import { useStore } from "vuex";
 
 export default {
   props: ["object"],
   components: { Object, MenuContent },
+  setup: (props) => {
+    const store = useStore();
+    const loggedIn = computed(() => store.getters["auth/loggedIn"]);
+    const holder = computed(() =>
+      store.state.stage.sessions.find((s) => s.avatarId === props.object.id)
+    );
+    provide("holder", holder);
+
+    const setAsPrimaryAvatar = () => {
+      if (loggedIn.value && !holder.value && props.object.type !== "prop") {
+        store
+          .dispatch("user/setAvatarId", props.object.id)
+          .then(props.closeMenu);
+      }
+    };
+
+    return { setAsPrimaryAvatar, holder };
+  },
 };
 </script>
 

--- a/ui/dashboard/src/components/objects/Object.vue
+++ b/ui/dashboard/src/components/objects/Object.vue
@@ -3,7 +3,7 @@
     ref="el"
     tabindex="0"
     @keyup.delete="deleteObject"
-    @click="$emit('hold')"
+    @click="hold"
     :style="{
       ...(object.speak ? { position: 'absolute', 'z-index': 20 } : {}),
     }"
@@ -19,8 +19,8 @@
         <DragResize
           v-if="controlable"
           class="object"
-          :initW="100"
-          :initH="100"
+          :initW="position.w"
+          :initH="position.h"
           v-model:x="position.x"
           v-model:y="position.y"
           v-model:w="position.w"
@@ -207,6 +207,12 @@ export default {
       }
     });
 
+    const hold = () => {
+      if (controlable.value && props.object.type !== "prop") {
+        store.dispatch("user/setAvatarId", props.object.id);
+      }
+    };
+
     return {
       el,
       print,
@@ -220,6 +226,7 @@ export default {
       deleteObject,
       src,
       stageSize,
+      hold,
       holder,
       controlable,
     };

--- a/ui/dashboard/src/components/objects/OpacitySlider.vue
+++ b/ui/dashboard/src/components/objects/OpacitySlider.vue
@@ -18,9 +18,6 @@
     }"
     v-show="active"
     @change="handleChange"
-    @mousedown.stop="keepActive"
-    @mouseover.stop="keepActive"
-    @mouseup.stop="keepActive"
   />
 </template>
 
@@ -29,8 +26,7 @@ import { computed } from "vue";
 import { useStore } from "vuex";
 export default {
   props: ["position", "active", "object"],
-  emits: ["update:active"],
-  setup: (props, { emit }) => {
+  setup: (props) => {
     const store = useStore();
     const sliderMode = computed(() => store.state.stage.preferences.slider);
     const maxFrameSpeed = 50;
@@ -77,12 +73,7 @@ export default {
       });
     };
 
-    const keepActive = () => {
-      emit("update:active", true);
-    };
-
     const handleChange = (e) => {
-      keepActive();
       switch (sliderMode.value) {
         case "opacity":
           sendChangeOpacity(e);
@@ -96,7 +87,7 @@ export default {
       }
     };
 
-    return { keepActive, handleChange, value, sliderMode };
+    return { handleChange, value, sliderMode };
   },
 };
 </script>

--- a/ui/dashboard/src/components/objects/Topping.vue
+++ b/ui/dashboard/src/components/objects/Topping.vue
@@ -6,8 +6,15 @@
       left: position.x + position.w / 2 + 'px',
     }"
   >
-    <span v-show="active" class="icon">
-      <Icon class="marker" src="my-avatar.svg" />
+    <span
+      v-if="holder"
+      class="icon marker"
+      :class="{ inactive: !active }"
+      :data-tooltip="`${object.name ? object.name + ' held by' : 'Held by'} ${
+        holder.nickname
+      }`"
+    >
+      <Icon src="my-avatar.svg" />
     </span>
     <transition @enter="enter" @leave="leave" :css="false" appear>
       <div
@@ -28,7 +35,7 @@
 </template>
 
 <script>
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import { useStore } from "vuex";
 import anime from "animejs";
 import Icon from "@/components/Icon";
@@ -37,6 +44,7 @@ export default {
   components: { Icon },
   setup: (props) => {
     const store = useStore();
+    const holder = inject("holder");
     const active = computed(
       () => props.object.id === store.state.user.avatarId
     );
@@ -61,7 +69,7 @@ export default {
       });
     };
 
-    return { active, enter, leave };
+    return { active, enter, leave, holder };
   },
 };
 </script>
@@ -88,7 +96,7 @@ export default {
 }
 .marker {
   position: absolute;
-  left: -8px;
+  left: -10px;
   -webkit-animation: spin 2s linear infinite;
   -moz-animation: spin 2s linear infinite;
   animation: spin 2s linear infinite;
@@ -108,5 +116,8 @@ export default {
     -webkit-transform: rotate3d(0, 1, 0, 360deg);
     transform: rotate3d(0, 1, 0, 360deg);
   }
+}
+.inactive {
+  filter: grayscale(1);
 }
 </style>

--- a/ui/dashboard/src/components/stage/SettingPopup/settings/Chat.vue
+++ b/ui/dashboard/src/components/stage/SettingPopup/settings/Chat.vue
@@ -30,7 +30,7 @@ export default {
     const form = reactive({});
     const loading = ref(false);
     const store = useStore();
-    const nickname = computed(() => store.getters["user/nickname"]);
+    const nickname = computed(() => store.getters["user/chatname"]);
     const saveNickname = () => {
       loading.value = true;
       store.dispatch("user/saveNickname", form).then((nickname) => {

--- a/ui/dashboard/src/components/stage/Toolbox/tools/Backdrop.vue
+++ b/ui/dashboard/src/components/stage/Toolbox/tools/Backdrop.vue
@@ -9,19 +9,20 @@
   >
     <Image v-if="background.src" :src="background.src" />
     <div v-else>
-      <div class="icon is-large"><i class="fas fa-ban fa-2x"></i></div>
+      <div class="icon is-large"><Icon size="36" src="clear.svg" /></div>
       <span class="tag is-light is-block">Clear</span>
     </div>
   </div>
 </template>
 
 <script>
-import Image from "@/components/Image";
 import { useStore } from "vuex";
 import { computed } from "vue";
+import Image from "@/components/Image";
+import Icon from "@/components/Icon";
 
 export default {
-  components: { Image },
+  components: { Image, Icon },
   setup: () => {
     const store = useStore();
     const currentBackground = computed(() => store.state.stage.background);

--- a/ui/dashboard/src/services/graphql/user.js
+++ b/ui/dashboard/src/services/graphql/user.js
@@ -11,12 +11,11 @@ export const userFragment = gql`
     lastName
     displayName
     email
-    phone
     active
     createdOn
     agreedToTerms
-    okToSms
     role
+    uploadLimit
   }
 `
 
@@ -32,8 +31,8 @@ export default {
     ${userFragment}
   `, variables),
   updateUser: (variables) => client.request(gql`
-    mutation UpdateUser($id: ID!, $displayName: String, $firstName: String, $lastName: String, $email: String, $password: String, $phone: String, $agreedToTerms: Boolean, $okToSms: Boolean, $active: Boolean, $role: Int) {
-      updateUser(inbound: {id: $id, displayName: $displayName, firstName: $firstName, lastName: $lastName, email: $email, password: $password, phone: $phone, agreedToTerms: $agreedToTerms, okToSms: $okToSms, active: $active, role: $role}) {
+    mutation UpdateUser($id: ID!, $displayName: String, $firstName: String, $lastName: String, $email: String, $password: String, $agreedToTerms: Boolean, $active: Boolean, $role: Int, $uploadLimit: Int) {
+      updateUser(inbound: {id: $id, displayName: $displayName, firstName: $firstName, lastName: $lastName, email: $email, password: $password, agreedToTerms: $agreedToTerms, active: $active, role: $role, uploadLimit: $uploadLimit}) {
         user {
           ...userFragment
         }

--- a/ui/dashboard/src/store/modules/stage/index.js
+++ b/ui/dashboard/src/store/modules/stage/index.js
@@ -328,9 +328,9 @@ export default {
         },
         sendChat({ rootGetters, state, getters }, message) {
             if (!message) return;
-            const nickname = rootGetters["user/nickname"];
+            const user = rootGetters["user/chatname"];
             const payload = {
-                user: nickname,
+                user,
                 message: message,
                 color: state.chat.color.text,
                 backgroundColor: state.chat.color.bg,
@@ -358,7 +358,7 @@ export default {
             }
             commit('PUSH_CHAT_MESSAGE', model)
         },
-        placeObjectOnStage({ commit }, data) {
+        placeObjectOnStage({ commit, dispatch }, data) {
             const object = {
                 id: uuidv4(),
                 w: 100,
@@ -374,6 +374,7 @@ export default {
             if (object.type === 'stream') {
                 commit('PUSH_STREAM_HOST', object);
             }
+            dispatch("user/setAvatarId", object.id, { root: true });
             return object;
         },
         shapeObject(action, object) {
@@ -525,12 +526,13 @@ export default {
             const id = state.session
             const isPlayer = rootGetters['auth/loggedIn'];
             const nickname = rootGetters['user/nickname'];
+            const avatarId = rootGetters['user/avatarId'];
             const session = state.sessions.find(s => s.id === id)
             const at = +new Date()
             if (session) {
-                Object.assign(session, { isPlayer, nickname, at })
+                Object.assign(session, { isPlayer, nickname, at, avatarId })
             } else {
-                state.sessions.push({ id, isPlayer, nickname, at })
+                state.sessions.push({ id, isPlayer, nickname, at, avatarId })
             }
             await mqtt.sendMessage(TOPICS.COUNTER, state.sessions);
         },

--- a/ui/dashboard/src/views/live/ConnectionStatus.vue
+++ b/ui/dashboard/src/views/live/ConnectionStatus.vue
@@ -83,7 +83,7 @@ export default {
   position: fixed;
   right: 12px;
   top: 50px;
-  width: 150px;
+  width: 250px;
   text-align: center;
   z-index: 2;
 

--- a/ui/dashboard/src/views/live/Session.vue
+++ b/ui/dashboard/src/views/live/Session.vue
@@ -31,5 +31,8 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
+div {
+  text-align: left;
+}
 </style>


### PR DESCRIPTION
Issue #219:
- [x] When you drag an avatar onto the stage, the default is that you are "holding" it.
- [x] "holding" an avatar allows you to manipulate and speak as this avatar
- [x] No other player can manipulate or speak as the avatar that you are holding
- [x] You can release a holding avatar using the context menu
- [x] The red turning icon above the avatar indicates that you are holding it; The gray turning icon indicates that someone else is holding it and you can't steal it from them. Hover on these icon will display the name of the avatar and the name of the player (Relate to issue #225). The frame for scaling only show when you click on the avatar, rather than all the time


<img width="1038" alt="Screenshot 2021-04-06 at 14 50 40" src="https://user-images.githubusercontent.com/29925961/113677243-923cc500-96e7-11eb-80eb-e35b4f6eec51.png">
