### PR TITLE
Issue 218 Upload Limit

### DIFF
--- a/config/schema.py
+++ b/config/schema.py
@@ -1,0 +1,43 @@
+# -*- coding: iso8859-15 -*-
+from config.project_globals import app
+from flask_graphql import GraphQLView
+from config.settings import VERSION
+from graphene import relay
+import graphene
+
+
+class NginxConfig(graphene.ObjectType):
+    uploadLimit = graphene.Int()
+
+    def resolve_uploadLimit(self, info):
+        nginx_config = 'system/dev/upstage.nginx'
+        with open(nginx_config) as file:
+            for line in file:
+                line = line.strip().lower()
+                if line.startswith('client_max_body_size'):
+                    limit = line.split(' ')[1]
+                    if limit.endswith(';'):
+                        limit = limit[0:-1]
+                    if limit.endswith('k'):
+                        limit = int(limit[0:-1])*1024
+                    if limit.endswith('m'):
+                        limit = int(limit[0:-1])*1024*1024
+        return limit
+
+
+class Query(graphene.ObjectType):
+    node = relay.Node.Field()
+    nginx = graphene.Field(NginxConfig)
+
+    def resolve_nginx(self, info):
+        return NginxConfig()
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+config_schema = graphene.Schema(query=Query)
+app.add_url_rule(
+    f'/{VERSION}/config_graphql/', view_func=GraphQLView.as_view(
+        "config_graphql", schema=config_schema,
+        graphiql=True
+    )
+)

--- a/run_upstage.py
+++ b/run_upstage.py
@@ -25,6 +25,7 @@ from asset import asset
 from asset.views import assets
 from license.views import licenses
 from stage import schema
+from config import schema
 
 # Below, duplicate names are actually app names.
 # See __init__.py in each directory to verify app name.

--- a/ui/dashboard/src/App.vue
+++ b/ui/dashboard/src/App.vue
@@ -10,6 +10,7 @@ export default {
     onMounted(() => {
       const store = useStore();
       store.dispatch("user/fetchCurrent");
+      store.dispatch("config/fetchConfig");
     });
   },
 };

--- a/ui/dashboard/src/components/MediaUpload.vue
+++ b/ui/dashboard/src/components/MediaUpload.vue
@@ -25,7 +25,6 @@
             data.file = $event;
             handleBlurName();
           "
-          :unlimit="data.mediaType === 'stream'"
           :accept-image="
             ['avatar', 'prop', 'backdrop', null].includes(data.mediaType)
           "

--- a/ui/dashboard/src/services/graphql/config.js
+++ b/ui/dashboard/src/services/graphql/config.js
@@ -1,0 +1,14 @@
+import { gql } from "graphql-request";
+import { createClient } from "./graphql";
+
+const client = createClient('config_graphql')
+
+export default {
+  configs: () => client.request(gql`
+    query {
+      nginx {
+        uploadLimit
+      } 
+    }
+  `),
+}

--- a/ui/dashboard/src/services/graphql/index.js
+++ b/ui/dashboard/src/services/graphql/index.js
@@ -1,4 +1,5 @@
 import userGraph from './user'
 import stageGraph from './stage'
+import configGraph from './config'
 
-export { userGraph, stageGraph }
+export { userGraph, stageGraph, configGraph }

--- a/ui/dashboard/src/store/index.js
+++ b/ui/dashboard/src/store/index.js
@@ -4,6 +4,7 @@ import auth from "./modules/auth";
 import user from "./modules/user";
 import stage from "./modules/stage";
 import cache from "./modules/cache";
+import config from "./modules/config";
 
 const dataState = createPersistedState({
   paths: ["auth"],
@@ -14,7 +15,8 @@ export default createStore({
     auth,
     user,
     stage,
-    cache
+    cache,
+    config
   },
   plugins: [dataState],
 })

--- a/ui/dashboard/src/store/modules/config.js
+++ b/ui/dashboard/src/store/modules/config.js
@@ -1,0 +1,25 @@
+import { configGraph } from "@/services/graphql";
+
+export default {
+    namespaced: true,
+    state: {
+        nginx: {},
+    },
+    getters: {
+        uploadLimit(state) {
+            return state.nginx.uploadLimit ?? 1024 * 1024
+        }
+    },
+    mutations: {
+        STORE_CONFIG(state, configs) {
+            console.log
+            Object.assign(state, configs)
+        },
+    },
+    actions: {
+        async fetchConfig({ commit }) {
+            const configs = await configGraph.configs()
+            commit('STORE_CONFIG', configs);
+        }
+    }
+};

--- a/ui/dashboard/src/store/modules/stage/index.js
+++ b/ui/dashboard/src/store/modules/stage/index.js
@@ -258,7 +258,7 @@ export default {
         },
         UPDATE_SESSIONS_COUNTER(state, sessions) {
             if (sessions && sessions.length) {
-                state.sessions = sessions.filter(s => moment().diff(moment(new Date(s.at)), 'hours') < 12);
+                state.sessions = sessions.filter(s => moment().diff(moment(new Date(s.at)), 'minute') < 60);
                 state.sessions.sort((a, b) => b.at - a.at);
             }
         }


### PR DESCRIPTION
- New graphql endpoint: `config_graphql` for query (and mutation in the future) server's configurations
- Remove `unlimit` size limit, replace it with the max upload size that nginx allow for upload videos
- Upload hint as Elisa proposed
<img width="1125" alt="Screenshot 2021-04-07 at 22 10 23" src="https://user-images.githubusercontent.com/29925961/113890081-0eb9cb80-97ee-11eb-8c82-4a71233b44ff.png">
