### PR TITLE
Change Target Branch for App1

### DIFF
--- a/.github/workflows/app1.yml
+++ b/.github/workflows/app1.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or approved pull request on R1-2021 branch
   push:
-    branches: [ R1-2021 ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Now that R1-2021 is finished, we should have app1 always follow the main branch.